### PR TITLE
Add an occurrence selection syntax to the material mesh field

### DIFF
--- a/Source/TexturesUnlimited/Util/TextureSet.cs
+++ b/Source/TexturesUnlimited/Util/TextureSet.cs
@@ -241,14 +241,14 @@ namespace KSPShaderTools
 
         private static bool TryParseNameAndOccurrence(string fullName, out string name, out int occurrence)
         {
-            // Check for a comma in the second-to-last position.
+            // Check if the name contains a comma.
             // If so parse everything before as the name and everything following as the occurrence number.
 
             name = default;
             occurrence = default;
-            int commaIndex = Mathf.Max(fullName.Length - 2, 0);
+            int commaIndex = fullName.LastIndexOf(',');
 
-            if (fullName[commaIndex] != ',' || !int.TryParse(fullName.Substring(commaIndex + 1), out occurrence))
+            if (commaIndex < 0 || !int.TryParse(fullName.Substring(commaIndex + 1), out occurrence))
                 return false;
 
             name = fullName.Substring(0, commaIndex);

--- a/Source/TexturesUnlimited/Util/TextureSet.cs
+++ b/Source/TexturesUnlimited/Util/TextureSet.cs
@@ -173,6 +173,8 @@ namespace KSPShaderTools
                 int len = rends.Length;
                 for (int i = 0; i < len; i++)
                 {
+                    // For completeness, "name,occurrence" could be supported here as well, but so far there is no use case.
+
                     if (!excludeMeshes.Contains(rends[i].name))
                     {
                         Log.extra("Adding mesh due to blacklist: " + rends[i].transform);
@@ -204,6 +206,17 @@ namespace KSPShaderTools
                 Renderer r;
                 for (int i = 0; i < len; i++)
                 {
+                    // Check if the mesh name is in the format of "name,occurrence".
+                    if (TryParseNameAndOccurrence(meshes[i], out string name, out int occurrence))
+                    {
+                        // Find the zero-based occurrence of the child with the given name.
+                        tr = root.FindExactChild(name, occurrence);
+                        if (tr != null && tr.GetComponent<Renderer>() != null)
+                            transforms.AddUnique(tr);
+
+                        continue;
+                    }
+
                     trs = root.FindChildren(meshes[i]);
                     int len2 = trs.Length;
                     for (int k = 0; k < len2; k++)
@@ -224,6 +237,22 @@ namespace KSPShaderTools
                 }
             }
             return transforms.ToArray();
+        }
+
+        private static bool TryParseNameAndOccurrence(string fullName, out string name, out int occurrence)
+        {
+            // Check for a comma in the second-to-last position.
+            // If so parse everything before as the name and everything following as the occurrence number.
+
+            name = default;
+            occurrence = default;
+            int commaIndex = Mathf.Max(fullName.Length - 2, 0);
+
+            if (fullName[commaIndex] != ',' || !int.TryParse(fullName.Substring(commaIndex + 1), out occurrence))
+                return false;
+
+            name = fullName.Substring(0, commaIndex);
+            return true;
         }
 
         /// <summary>

--- a/Source/TexturesUnlimited/Util/Utils.cs
+++ b/Source/TexturesUnlimited/Util/Utils.cs
@@ -609,6 +609,43 @@ namespace KSPShaderTools
         }
 
         /// <summary>
+        /// Searches recursively for the child transform that is the given occurrence of a child with the given name. 
+        /// </summary>
+        /// <param name="transform">The transform from which to begin the search.</param>
+        /// <param name="name">The transform name to match with.</param>
+        /// <param name="occurrence">The zero-based occurrence of the given transform name to match with.</param>
+        /// <returns>The child with the given name and name occurrence or null if not found.</returns>
+        public static Transform FindExactChild(this Transform transform, String name, int occurrence)
+        {
+            int count = 0;
+            return FindExactChildRecursion(name, occurrence, ref transform, ref count) ? transform : null;
+        }
+
+        private static bool FindExactChildRecursion(String name, int index, ref Transform transform, ref int count)
+        {
+            if (transform.name == name)
+            {
+                if (count == index)
+                    return true;
+
+                count++;
+            }
+
+            // Is it necessary to store the parent transform? Or does the foreach loop keep the original reference?
+            // Would it be faster to return a Transform and null check each child than to return a bool and juggle variables on the stack?
+            Transform parent = transform; 
+
+            foreach (Transform child in parent)
+            {
+                transform = child; // Can't use a foreach variable as a ref.
+                if (FindExactChildRecursion(name, index, ref transform, ref count))
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Searches entire model heirarchy from the input transform to end of branches for transforms with the input transform name and returns the first match found, or null if none.
         /// </summary>
         /// <param name="transform"></param>

--- a/Source/TexturesUnlimited/Util/Utils.cs
+++ b/Source/TexturesUnlimited/Util/Utils.cs
@@ -621,11 +621,11 @@ namespace KSPShaderTools
             return FindExactChildRecursion(name, occurrence, ref transform, ref count) ? transform : null;
         }
 
-        private static bool FindExactChildRecursion(String name, int index, ref Transform transform, ref int count)
+        private static bool FindExactChildRecursion(String name, int occurrence, ref Transform transform, ref int count)
         {
             if (transform.name == name)
             {
-                if (count == index)
+                if (count == occurrence)
                     return true;
 
                 count++;
@@ -638,7 +638,7 @@ namespace KSPShaderTools
             foreach (Transform child in parent)
             {
                 transform = child; // Can't use a foreach variable as a ref.
-                if (FindExactChildRecursion(name, index, ref transform, ref count))
+                if (FindExactChildRecursion(name, occurrence, ref transform, ref count))
                     return true;
             }
 


### PR DESCRIPTION
Lets the config author select which occurence of a mesh with a given name they'd like to include in the whitelist.

The motivation for this is to solve this [issue](https://github.com/PorktoberRevolution/ReStocked/issues/1027) that the developers of Restock Recolour brought to Restock about a model that contained two objects with the exact same name, but needed to be given two different textures.

![image](https://github.com/user-attachments/assets/511347cb-afb0-40ea-bae2-712310b2e8cd)

`mesh = DockingPortShldBase,1` would be used to select the second occurrence of the mesh with that exact name.



