### PR TITLE
Allow detail to be Loaded from Config

### DIFF
--- a/Source/TexturesUnlimited/Addon/TexturesUnlimitedLoader.cs
+++ b/Source/TexturesUnlimited/Addon/TexturesUnlimitedLoader.cs
@@ -783,6 +783,7 @@ namespace KSPShaderTools
         public Color color;
         public float specular;
         public float metallic;
+        public float detail;
 
         public RecoloringDataPreset(ConfigNode node)
         {
@@ -791,6 +792,7 @@ namespace KSPShaderTools
             color = node.GetColor("color");
             specular = node.GetColorChannelValue("specular");
             metallic = node.GetColorChannelValue("metallic");
+            detail = node.GetColorChannelValue("detail");
         }
 
         public RecoloringData getRecoloringData()

--- a/Source/TexturesUnlimited/Util/Utils.cs
+++ b/Source/TexturesUnlimited/Util/Utils.cs
@@ -488,6 +488,7 @@ namespace KSPShaderTools
             string value = node.GetStringValue(name).Trim();
             float floatValue = safeParseFloat(value);
             if (value.Contains(".")) { return floatValue; }
+            if (name == "detail") { return floatValue / 100; }
             return floatValue / 255f;
         }
 


### PR DESCRIPTION
This will allow detail to be loaded like the other recolor variables. Not sure why it was originally excluded from being loaded, but I found it cumbersome to have to adjust the value every time I loaded a preset. Current presets would need to be updated otherwise when loading a preset without a value saved for detail the value will default to 0 instead of the current default of 100. I submitted a pull already to LazyPainter so that it will save the value of detail for all new created presets.