### PR TITLE
Fix loading detail from presets and make backwards compatible

### DIFF
--- a/Source/TexturesUnlimited/Addon/TexturesUnlimitedLoader.cs
+++ b/Source/TexturesUnlimited/Addon/TexturesUnlimitedLoader.cs
@@ -797,7 +797,7 @@ namespace KSPShaderTools
 
         public RecoloringData getRecoloringData()
         {
-            return new RecoloringData(color, specular, metallic, 1);
+            return new RecoloringData(color, specular, metallic, detail);
         }
     }
 

--- a/Source/TexturesUnlimited/GUI/CraftRecolorGUI.cs
+++ b/Source/TexturesUnlimited/GUI/CraftRecolorGUI.cs
@@ -453,7 +453,7 @@ namespace KSPShaderTools
                     bStr = (editingColor.color.b * 255f).ToString("F0");
                     aStr = (editingColor.specular * 255f).ToString("F0");
                     mStr = (editingColor.metallic * 255f).ToString("F0");
-                    //dStr = (editingColor.detail * 100f).ToString("F0");//leave detail mult as pre-specified value (user/config); it does not pull from preset colors at all
+                    dStr = (editingColor.detail * 100f).ToString("F0");
                     update = true;
                 }
                 GUI.color = old;

--- a/Source/TexturesUnlimited/Util/Utils.cs
+++ b/Source/TexturesUnlimited/Util/Utils.cs
@@ -486,6 +486,13 @@ namespace KSPShaderTools
         public static float GetColorChannelValue(this ConfigNode node, string name)
         {
             string value = node.GetStringValue(name).Trim();
+
+            // Detail was not included in presets originally, so on old presets GetStringValue will return "", which will default to 0.
+            // Default to 1 instead if trying to access detail, which results in a default detail of 100, as before.
+
+            if (value == "" && name == "detail")
+                return 1f;
+
             float floatValue = safeParseFloat(value);
             if (value.Contains(".")) { return floatValue; }
             if (name == "detail") { return floatValue / 100; }


### PR DESCRIPTION
I've taken a ridiculously long time to get round to this, but https://github.com/KSPModStewards/TexturesUnlimited/pull/5 doesn't seem complete to me. Mainly it provides a detail value of 1 all the time, and I don't see any way for it to return anything other than 1. Is there something I'm missing @svm420? You mentioned it was working for you with no issues.

These are the necessary changes to get it working how I expected.